### PR TITLE
ci: run unit tests on push

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,6 @@ name: Unit tests
 
 on:
   push:
-    branches:
-      - main
-  pull_request: { }
 
 permissions:
   contents: read


### PR DESCRIPTION
Unit tests should be run on push, so that contributors does not need to create pull requests to get their code evaluated by `Github Actions`.

Since the workflow is run on every push, we do not need special handling for pull request.