### PR TITLE
Bump browserless image version that is used in the integration test

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -345,7 +345,7 @@ func setupBrowser(ctx context.Context) (host string, port int, err error) {
 			Env: map[string]string{
 				"DEBUG": "*",
 			},
-			Image:        "browserless/chrome:1.33.1-puppeteer-3.0.0",
+			Image:        "browserless/chrome:1.36.0-puppeteer-3.3.0",
 			ExposedPorts: []string{"3000/tcp"},
 			WaitingFor:   wait.ForListeningPort("3000/tcp"),
 		},


### PR DESCRIPTION
browserless version 1.36.0-puppeteer-3.3.0 use chrome version 83.0.4103.116 which corresponds with the current version of chromedp and cdproto. It is assumed that this is the latest version of browserless that is compatible.

Upgrading to the 1.37.0 series of browserless use Google Chrome version 84.0.4147.105 which requires upgrading chromedp and cdproto to versions that need code changes.