### PR TITLE
Add support for async scripts

### DIFF
--- a/session/script.go
+++ b/session/script.go
@@ -19,6 +19,7 @@ package session
 import (
 	"context"
 	"fmt"
+	"strings"
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
@@ -198,6 +199,10 @@ func (sess *Session) executeScripts(ctx context.Context, scriptType configV1.Bro
 // Returns an error: if the debug protocol action fails, if script execution
 // caused an exception, or if unmarshalling of result value fails.
 func callScript(ctx context.Context, eci runtime.ExecutionContextID, functionDeclaration string, arguments easyjson.RawMessage) (easyjson.RawMessage, error) {
+	var awaitPromise bool
+	if strings.HasPrefix(functionDeclaration, "async ") {
+		awaitPromise = true
+	}
 	var res *runtime.RemoteObject
 	var exceptionDetails *runtime.ExceptionDetails
 	err := chromedp.Run(ctx,
@@ -207,6 +212,7 @@ func callScript(ctx context.Context, eci runtime.ExecutionContextID, functionDec
 				WithArguments([]*runtime.CallArgument{{Value: arguments}}).
 				WithExecutionContextID(eci).
 				WithReturnByValue(true).
+				WithAwaitPromise(awaitPromise).
 				Do(ctx)
 			return err
 		}),

--- a/session/session.go
+++ b/session/session.go
@@ -589,12 +589,19 @@ func (sess *Session) extractOutlinks() []string {
 			Str("scriptId", s.GetId()).
 			Logger()
 
+		script := s.GetBrowserScript().GetScript()
+		var awaitPromise bool
+		if strings.HasPrefix(script, "(async ") {
+			awaitPromise = true
+		}
 		var res *runtime.RemoteObject
 		var exceptionDetails *runtime.ExceptionDetails
 		err := chromedp.Run(sess.ctx,
 			chromedp.ActionFunc(func(ctx context.Context) (err error) {
-				res, exceptionDetails, err = runtime.Evaluate(s.GetBrowserScript().GetScript()).
-					WithReturnByValue(true).Do(ctx)
+				res, exceptionDetails, err = runtime.Evaluate(script).
+					WithReturnByValue(true).
+					WithAwaitPromise(awaitPromise).
+					Do(ctx)
 				return err
 			}),
 		)


### PR DESCRIPTION
This PR enables using async scripts both for ON_NEW_DOCUMENT, ON_LOAD and EXTRACT_OUTLINKS type scripts.

To qualify as async, ON_NEW_DOCUMENT and ON_LOAD type scripts (including any "next" scripts) must begin with `async `.

To qualify as async, EXTRACT_OUTLINKS type scripts must start with `(async `. Extract outlink scripts are run in the global context and should therefore be IIFE (https://developer.mozilla.org/en-US/docs/Glossary/IIFE).